### PR TITLE
Fix MySQLDatabaseManager#truncateDb to include ignoreTables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgresrootpassword
       - POSTGRES_USER=postgres
-  mssql:
-    image: microsoft/mssql-server-linux
-    ports:
-      - "11433:1433"
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=mssqlpassword
+#  mssql:
+#    image: microsoft/mssql-server-linux
+#    ports:
+#      - "11433:1433"
+#    environment:
+#      - ACCEPT_EULA=Y
+#      - SA_PASSWORD=mssqlpassword
 # Actually its better to install oracle directly on host to be
 # able to compile node-oracledb to connect the DB
 #  oracledbxe:

--- a/lib/MySqlDatabaseManager.js
+++ b/lib/MySqlDatabaseManager.js
@@ -86,7 +86,9 @@ MySqlDatabaseManager.prototype.truncateDb = function(ignoreTables) {
       return knex.transaction(function(trx) {
         return knex.raw('SET FOREIGN_KEY_CHECKS = 0').transacting(trx)
           .then(function() {
-            return Promise.map(tableNames, function(tableName) {
+            // ignore the tables based on `ignoreTables`
+            var filteredTables = _.differenceWith(tableNames, ignoreTables, _.isEqual);
+            return Promise.map(filteredTables, function(tableName) {
               return knex.table(tableName).truncate().transacting(trx);
             }, {concurrency: 1});
           });

--- a/tests/database-manager.spec.js
+++ b/tests/database-manager.spec.js
@@ -212,13 +212,16 @@ _.map(availableDatabases, function (dbManager) {
     });
 
     it("#truncateDb should truncate a database", function () {
-      return dbManager.truncateDb([migrations.tableName])
+      return dbManager.truncateDb([migrations.tableName, 'Ignoreme'])
         .then(function (result) {
           var knex = dbManager.knexInstance();
 
           return Promise.all([
             knex.select().from('User').then(function (result) {
               expect(result.length).to.equal(0);
+            }),
+            knex.select().from('Ignoreme').then(function (result) {
+              expect(result.length).to.equal(1);
             }),
             dbManager.dbVersion(dbManager.config.knex.connection.database).then(function (ver) {
               expect(ver).to.equal('20150623130922');

--- a/tests/migrations/20141024070315_test_schema.js
+++ b/tests/migrations/20141024070315_test_schema.js
@@ -1,11 +1,21 @@
 exports.up = function(knex) {
-  return knex.schema.createTable('User', function(table) {
-    table.bigincrements('id').primary();
-    table.string('username').index().unique().notNullable();
-    table.string('email');
-  });
+  return knex.schema
+    .createTable('User', function(table) {
+      table.bigincrements('id').primary();
+      table.string('username').index().unique().notNullable();
+      table.string('email');
+    })
+    .createTable('Ignoreme', function(table) {
+      table.bigincrements('id').primary();
+      table.string('description');
+    })
+    .then(function () {
+      return knex('Ignoreme').insert({ description: 'wat' });
+    });
 };
 
 exports.down = function(knex) {
-  return knex.schema.dropTable('User');
+  return knex.schema
+    .dropTable('User')
+    .dropTable('Ignoreme');
 };


### PR DESCRIPTION
When using MySQL, `truncateDb` did not filter the tables passed in as arguments when it was doing the actual truncate. This PR fixes that.

Should I be updating any of the tests? It looks like there is already a test to check this. 