### PR TITLE
fix: check for exports.seed in seed files

### DIFF
--- a/lib/DatabaseManager.js
+++ b/lib/DatabaseManager.js
@@ -94,19 +94,27 @@ DatabaseManager.prototype.updateIdSequences = function() {
  * @param {String=} populatePathPattern
  * @returns {Promise}
  */
-DatabaseManager.prototype.populateDb = function(populatePathPattern) {
-  populatePathPattern = populatePathPattern || this.config.populatePathPattern;
+ DatabaseManager.prototype.populateDb = function(populatePathPattern) {
+   populatePathPattern =
+     populatePathPattern || this.config.dbManager.populatePathPattern;
 
-  var knex = this.knexInstance();
-  var modules = multiRequire(populatePathPattern).filterModule(_.isFunction).require();
+   var knex = this.knexInstance();
+   var modules = multiRequire(populatePathPattern)
+     .filterModule(function(module) {
+       return _.isFunction(module.seed);
+     })
+     .require();
 
-  return Promise
-    .all(_.map(modules, function (module) {
-      return knex.transaction(function (trx) {
-        return module.module(trx);
-      });
-    }));
-};
+   return Promise.all(
+     _.map(modules, function(module) {
+       return knex.transaction(function(trx) {
+         return module.module.seed(trx).then(res => {
+           return module.fileName;
+         });
+       });
+     })
+   );
+ }
 
 /**
  * Runs migrations for database in knex config.


### PR DESCRIPTION
See #61 for details. Knex seed files expects `exports.seed`, where knex db manager does not. This is probably a breaking change as suggested by @elhigu. 