### PR TITLE
fix: 'Warning: a promise was rejected with a non-error: [object Undefined]' error #71

### DIFF
--- a/lib/PostgresDatabaseManager.js
+++ b/lib/PostgresDatabaseManager.js
@@ -32,7 +32,7 @@ PostgresDatabaseManager.prototype.createDb = function(databaseName) {
   var collate = this.config.dbManager.collate;
   var owner = this.config.knex.connection.user;
   var self = this;
-  var promise = Promise.reject();
+  var promise = Promise.reject(new Error());
 
   if (_.isEmpty(collate)) {
     promise = promise.catch(function () {


### PR DESCRIPTION
Hello,

I have the same exact problem described in the following issue (https://github.com/Vincit/knex-db-manager/issues/71), with Node.js `v10.15.1` and knex-db-manager `0.5.0`.

This pull-request removes the warning message even though I cannot reproduce it with the following snippet (https://github.com/Vincit/knex-db-manager/issues/71#issuecomment-522228980).

Having spent more time on this than I'd like to, without understanding where it comes from though, here's a fix that makes this headache disappear without breaking anything.

Thank you for the hard work and LMKWYT.

Cheers,