### PR TITLE
[Bugfix] Single quote the database owner

### DIFF
--- a/lib/PostgresDatabaseManager.js
+++ b/lib/PostgresDatabaseManager.js
@@ -36,14 +36,14 @@ PostgresDatabaseManager.prototype.createDb = function(databaseName) {
 
   if (_.isEmpty(collate)) {
     promise = promise.catch(function () {
-      return self._masterQuery("CREATE DATABASE %I OWNER = %I ENCODING = 'UTF-8' TEMPLATE template1", [databaseName, owner]);
+      return self._masterQuery("CREATE DATABASE %I OWNER = '%I' ENCODING = 'UTF-8' TEMPLATE template1", [databaseName, owner]);
     });
   } else {
     // Try to create with each collate. Use the first one that works. This is kind of a hack
     // but seems to be the only reliable way to make this work with both windows and unix.
     _.each(collate, function(locale) {
       promise = promise.catch(function() {
-        return self._masterQuery("CREATE DATABASE %I OWNER = %I ENCODING = 'UTF-8' LC_COLLATE = %L TEMPLATE template0", [databaseName, owner, locale]);
+        return self._masterQuery("CREATE DATABASE %I OWNER = '%I' ENCODING = 'UTF-8' LC_COLLATE = %L TEMPLATE template0", [databaseName, owner, locale]);
       });
     });
   }


### PR DESCRIPTION
There is an issue with our the version of PSQL (11.x) and this library.

We're trying to create a database using this library and the statement that this library use seems to be invalid with what PSQL expects.

From our experience, the CREATE DATABASE statement owner's parameter has to either be quoted such that it is:

`CREATE DATABASE appraisal OWNER = 'XX_USERNAME_XX' ENCODING = 'UTF-8' TEMPLATE template1` _(notice the single quotes surrounding XX_USERNAME_XX)_

or that it's written without the "equal" sign such as

`CREATE DATABASE appraisal OWNER XX_USERNAME_XX ENCODING = 'UTF-8' TEMPLATE template1` _(notice the lack of `=` sign between OWNER and XX_USERNAME_XX)_

Otherwise, we get errors on the PSQL database:

```
2020-01-20 18:28:32 UTC:10.2.1.125(51484):XX_USERNAME_XX@postgres:[32587]:ERROR: role "XX_USERNAME_XX" does not exist
2020-01-20 18:28:32 UTC:10.2.1.125(51484):XX_USERNAME_XX@postgres:[32587]:STATEMENT: CREATE DATABASE appraisal OWNER = XX_USERNAME_XX ENCODING = 'UTF-8' TEMPLATE template1
```

The documentation of PSQL seems to describe that it should work with the equal sign, but our experiences tells us otherwise. https://www.postgresql.org/docs/11/sql-createdatabase.html

Adding this change fixed our issues. To be honest, I couldn't test it on other PSQL versions, but I would assume that this isn't a breaking change.

Thanks for considering merging this!