### PR TITLE
Fix Warning: a promise was rejected with a non-error

### DIFF
--- a/lib/MySqlDatabaseManager.js
+++ b/lib/MySqlDatabaseManager.js
@@ -37,7 +37,7 @@ MySqlDatabaseManager.prototype.createDb = function(databaseName) {
   var collate = this.config.dbManager.collate;
   var owner = this.config.knex.connection.user;
   var self = this;
-  var promise = Promise.reject();
+  var promise = Promise.reject(new Error());
 
   if (_.isEmpty(collate)) {
     promise = promise.catch(function () {


### PR DESCRIPTION
a promise created with empty error gives annoying warning
`Warning: a promise was rejected with a non-error: [object Undefined]`