### PR TITLE
Fixed old-style seeding modules

### DIFF
--- a/lib/DatabaseManager.js
+++ b/lib/DatabaseManager.js
@@ -99,13 +99,19 @@ DatabaseManager.prototype.populateDb = function(populatePathPattern) {
 
   var knex = this.knexInstance();
   var modules = multiRequire(populatePathPattern)
-    .filterModule(_.isFunction)
+    .filterModule(function(module) {
+      return _.isFunction(module) || (module && _.isFunction(module.seed))
+    })
     .require();
 
   return Promise.all(
     _.map(modules, function(module) {
       return knex.transaction(function(trx) {
-        return module.module(trx);
+        if (_.isFunction(module.module)) {
+          module.module(trx);
+        } else if (module.module && _.isFunction(module.module.seed)) {
+          module.module.seed(trx);
+        }
       });
     })
   );

--- a/tests/database-manager.spec.js
+++ b/tests/database-manager.spec.js
@@ -232,7 +232,21 @@ _.map(availableDatabases, function(db) {
 
     it('#populateDb should populate data from given directory', function() {
       return dbManager
-        .populateDb(__dirname + '/populate/*.js')
+        .populateDb(__dirname + '/populate/*-data.js')
+        .then(function() {
+          var knex = dbManager.knexInstance();
+          return knex
+            .select()
+            .from('User')
+            .then(function(result) {
+              expect(parseInt(result[0].id)).to.equal(1);
+            });
+        });
+    });
+
+    it('#populateDb should populate data from given directory with seeding old export', function() {
+      return dbManager
+        .populateDb(__dirname + '/populate/*-old.js')
         .then(function() {
           var knex = dbManager.knexInstance();
           return knex

--- a/tests/populate/sample-data-old.js
+++ b/tests/populate/sample-data-old.js
@@ -1,0 +1,6 @@
+exports.seed = function(knex) {
+  return knex('User').insert({
+    username: 'dummy',
+    email: 'lol@fake.invalid',
+  });
+};


### PR DESCRIPTION
Hi there,

This PR handles both old (`exports.seed = function`) and new (`module.exports = function`) styles of seed files.

It duplicates and replaces the following PR: https://github.com/Vincit/knex-db-manager/pull/68