### PR TITLE
Set seeding to sequential instead of parallel

### DIFF
--- a/lib/DatabaseManager.js
+++ b/lib/DatabaseManager.js
@@ -102,13 +102,13 @@ DatabaseManager.prototype.populateDb = function(populatePathPattern) {
     .filterModule(_.isFunction)
     .require();
 
-  return Promise.all(
-    _.map(modules, function(module) {
+  return _.reduce(modules, function(res, module) {
+    return res.then(function() {
       return knex.transaction(function(trx) {
         return module.module(trx);
       });
-    })
-  );
+    });
+  }, Promise.resolve());
 };
 
 /**

--- a/tests/database-manager.spec.js
+++ b/tests/database-manager.spec.js
@@ -235,12 +235,20 @@ _.map(availableDatabases, function(db) {
         .populateDb(__dirname + '/populate/*.js')
         .then(function() {
           var knex = dbManager.knexInstance();
-          return knex
-            .select()
-            .from('User')
-            .then(function(result) {
-              expect(parseInt(result[0].id)).to.equal(1);
-            });
+          return Bluebird.all([
+            knex
+              .select()
+              .from('User')
+              .then(function(result) {
+                expect(parseInt(result[0].id)).to.equal(1);
+              }),
+            knex
+              .select()
+              .from('Pet')
+              .then(function(result) {
+                expect(parseInt(result[0].id)).to.equal(1);
+              }),
+          ]);
         });
     });
 

--- a/tests/migrations/20141024070315_test_schema.js
+++ b/tests/migrations/20141024070315_test_schema.js
@@ -9,6 +9,15 @@ exports.up = function(knex) {
         .notNullable();
       table.string('email');
     })
+    .createTable('Pet', function(table) {
+      table.bigincrements('id').primary();
+      table.string('name');
+      table
+        .biginteger('userid')
+        .unsigned()
+        .notNullable();
+      table.foreign('userid').references('User.id');
+    })
     .createTable('Ignoreme', function(table) {
       table.bigincrements('id').primary();
       table.string('description');
@@ -19,5 +28,8 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.dropTable('User').dropTable('Ignoreme');
+  return knex.schema
+    .dropTable('Pet')
+    .dropTable('User')
+    .dropTable('Ignoreme');
 };

--- a/tests/populate/01-user-data.js
+++ b/tests/populate/01-user-data.js
@@ -1,0 +1,12 @@
+module.exports = function(knex) {
+  return new Promise(function(resolve) {
+    setTimeout(function() {
+      return knex('User')
+        .insert({
+          username: 'dummy',
+          email: 'lol@fake.invalid',
+        })
+        .then(resolve);
+    }, 100);
+  });
+};

--- a/tests/populate/02-pet-data.js
+++ b/tests/populate/02-pet-data.js
@@ -1,0 +1,6 @@
+module.exports = function(knex) {
+  return knex('Pet').insert({
+    name: 'spot',
+    userid: '1',
+  });
+};

--- a/tests/populate/sample-data.js
+++ b/tests/populate/sample-data.js
@@ -1,6 +1,0 @@
-module.exports = function(knex) {
-  return knex('User').insert({
-    username: 'dummy',
-    email: 'lol@fake.invalid',
-  });
-};


### PR DESCRIPTION
Problem: when populating database by seeding `b.js` which uses keys from `a.js` as foreign keys, `populateDb` doesn not guarantee to respect alphabetical order and insert `a.js` before `b.js`.

Fix: use a sequential loop by executing one promise after each other.

Possible performance hit: might slow down seeding for big datasets (as each seed file is executed one after another).

Edit: removed commit from PR https://github.com/Vincit/knex-db-manager/pull/88.